### PR TITLE
Revise raw camera access API

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-Currently, to protect user privacy, WebXR Device API does not provide a way to grant raw camera access to the sites. Additionally, alternative ways for sites to obtain raw camera access (getUserMedia() web API) are not going to provide the application pose-synchronized camera images. For some scenarios, this limitation may pose a significant barrier to adoption of WebXR Device API. This is especially true given the fact that addition of new APIs takes time, thus stifling experimentation and prototyping that could happen purely in JavaScript.
+Currently, to protect user privacy, WebXR Device API does not provide a way to grant raw camera access to the sites. Additionally, alternative ways for sites to obtain raw camera access (`getUserMedia()` web API) are not going to provide the application pose-synchronized camera images that could be integrated with WebXR Device API. For some scenarios, this limitation may pose a significant barrier to adoption of WebXR. This is especially true given the fact that addition of new APIs takes time, thus stifling experimentation and prototyping that could happen purely in JavaScript.
 
-Given the above, it will be beneficial to provide the sites access to raw camera images through WebXR API. It does come with a potential risk related to the fact that the sites will be granted access to the images from the user's environment. To mitigate privacy aspects of providing such capability, implementers should ensure that appropriate user consent is collected before granting camera access to the site.
+Given the above, it is beneficial to provide the sites access to raw camera images directly through WebXR API. It does come with a potential risk related to the fact that the sites will be granted access to the images from the user's environment. To mitigate privacy aspects of providing such capability, implementers should ensure that appropriate user consent is collected before granting camera access to the site.
 
-The work in this repository describes experiments that should fall under the scope of immersive-web CG's [Computer Vision](https://github.com/immersive-web/computer-vision) repository.
+The work in this repository describes experiments that likely falls under the scope of immersive-web CG's [Computer Vision](https://github.com/immersive-web/computer-vision) repository.
 
 ## Use cases
 
@@ -21,6 +21,65 @@ Granting the camera access to the application could allow the applications to:
 The raw camera image access API should seamlessly integrate with APIs already exposed by the WebXR Device API. The Web IDL for proposed API could look roughly as follows:
 
 ```webidl
+partial interface XRView {
+  // Non-null iff there exists an associated camera that perfectly aligns with the view:
+  [SameObject] readonly attribute XRCamera? camera;
+};
+
+interface XRCamera {
+  // Dimensions of the camera image:
+  readonly attribute long width;
+  readonly attribute long height;
+};
+
+partial interface XRWebGLBinding {
+  // Access to the camera texture itself:
+  WebGLTexture? getCameraImage(XRCamera camera);
+};
+```
+
+This allows us to provide a time-indexed texture containing a camera image that is retrievable only when the XRFrame is considered active. The API should also be gated by the `“camera-access”` feature descriptor.
+
+The API is extensible to account for other (less smartphone-centric) scenarios by exposing a separate XRCamera type. The camera instances serve as handles to obtain the camera texture, and the WebXR API could add more sources of obtaining the XRCamera instances if need be. The XRCamera interface could also be easily extended.
+
+## Using the API
+
+The applications could leverage the newly introduced feature as follows:
+
+1. Create a session that supports accessing camera images:
+```javascript
+const session = await navigator.xr.requestSession(“immersive-ar”, {
+  requiredFeatures: [“camera-access”]
+});
+```
+
+If UA decides it needs to prompt the user for permission to use the camera, it can do so at this stage.
+
+2. In requestAnimationFrame callback, the application can iterate over the views and react appropriately when it finds a view with a camera associated with it:
+
+```javascript
+// ... in rAFcb ...
+let viewerPose = xrFrame.getViewerPose(xrRefSpace);
+for (const view of viewerPose.views) {
+  if (view.camera) {
+    // ... handle a view that has a camera image ...
+  }
+}
+```
+
+3. Using the view that has a non-null `camera` attribute, the application can then query the `XRWebGLBinding` for the camera image texture:
+```javascript
+// ... in rAFcb ...
+const cameraTexture = binding.getCameraImage(view.camera);
+```
+
+Side note: GL binding referred to in step 3. is an interface that is newly introduced in the [WebXR Layers Module](https://immersive-web.github.io/layers/#XRWebGLBindingtype). It can be [constructed](https://immersive-web.github.io/layers/#dom-xrwebglbinding-xrwebglbinding) given an `XRSession` and `XRWebGLRenderingContext`.
+
+## Alternatives considered
+
+### Initial API proposal
+
+```webidl
 partial interface XRWebGLBinding {
   WebGLTexture? getCameraImage(XRFrame frame, XRView view);
 };
@@ -30,31 +89,6 @@ partial interface XRViewerPose {
 };
 ```
 
-This allows us to provide a time-indexed texture containing a camera image that is retrievable only when the XRFrame is considered active. The API should also be gated by the `“cameraAccess”` feature descriptor.
+The initial proposal of the API used an `XRView` type as a handle that can then be used to query the camera image from the system. The camera intrinsics could be calculated by inspecting the projection matrix of the XRView. In case the system wanted to surface a camera image that is not aligned with any of the existing views, it would have to artificially create additional `XRView` instances.
 
-## Using the API
-
-The applications could leverage the newly introduced feature as follows:
-
-1. Create a session that supports accessing camera images:
-```javascript
-navigator.xr.requestSession(“immersive-ar”, { requiredFeatures: [“cameraAccess”]}).then(...);
-```
-
-If UA decides it needs to prompt the user for permission to use the camera, it can do so at this stage.
-
-2. In requestAnimationFrame callback, the application can query for the camera view for which it’s interested in accessing the camera image:
-
-```javascript
-// ... in rAFcb ...
-let viewerPose = xrFrame.getViewerPose(xrRefSpace);
-let cameraView = viewerPose.cameraViews[0];
-```
-
-3. Using the camera view, the application can then query the gl binding for the camera image texture:
-```javascript
-// ... in rAFcb ...
-let cameraTexture = binding.getCameraImage(xrFrame, cameraView);
-```
-
-Side note: GL binding referred to in step 4. is an interface that is newly introduced in the [WebXR Layers Module](https://immersive-web.github.io/layers/#XRWebGLBindingtype). It can be constructed given a XRSession and GL rendering context.
+This API shape was not very extensible as it did not offer a clear way of adding camera-specific properties - they would have to be added to an `XRView`. In the likely case the API would have to be extended to account for cameras that are not aligned with views, the API shape did not offer nice / obvious extension points.


### PR DESCRIPTION
Add new interface that could serve as an extension point in case we need
to add a more general-purpose camera API for cameras not perfectly
aligned with XRViews exposed via XRViewerPose.